### PR TITLE
bgpdump_file.c: Fix segfault on relative path without /

### DIFF
--- a/src/bgpdump_file.c
+++ b/src/bgpdump_file.c
@@ -194,6 +194,8 @@ get_file_filename (char *filepath)
   p = rindex (filepath, '/');
   if (p)
     p++;
+  else
+    p = filepath;
   if (strlen (p) == 0)
     return std_in;
   if (! strcmp (p, "-"))


### PR DESCRIPTION
./bgpdump2 -v rib
Segmentation fault (core dumped)

in gdb:
```
Program received signal SIGSEGV, Segmentation fault.
0x000055555555cb6d in get_file_filename (filepath=0x7fffffffe034 "rib") at /home/nuclearcat/Documents/DNS2ASPATH/bgpdump2_src/src/bgpdump_file.c:197
197	  if (strlen (p) == 0)
```